### PR TITLE
Fixes providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ providers:
       - '/departamento-alquiler-la-plata-casco-urbano.html?cambientes=2.'
 ```
 
+If you have issues with SSL certificates you can disable SSL validation with the attribute `disable_ssl`, by default it is enabled.
+
 One final step, you need to initialize the database. Just run `python3 setup.py` and that's it. It will create a sqlite3 db file in the root folder.
 
 You're all set. Now run `python3 main.py` and sit tight!

--- a/configuration.sample.yml
+++ b/configuration.sample.yml
@@ -9,4 +9,4 @@ providers:
         base_url: <URL>
         sources:
           - <PATH>
-
+disable_ssl: true | false

--- a/providers/base_provider.py
+++ b/providers/base_provider.py
@@ -1,19 +1,32 @@
 import logging
 import cloudscraper
 from abc import ABC, abstractmethod
+from providers.hostname_ignoring_adapter import HostNameIgnoringAdapter
+import yaml
 
+# configuration    
+with open("configuration.yml", 'r') as ymlfile:
+    print('loading config')
+    cfg = yaml.safe_load(ymlfile)
+
+disable_ssl = False
+
+if 'disable_ssl' in cfg:
+    disable_ssl = cfg['disable_ssl']
 class BaseProvider(ABC):
     def __init__(self, provider_name, provider_data):
         self.provider_name = provider_name
         self.provider_data = provider_data
         self.__scraper = cloudscraper.create_scraper()
+        if disable_ssl:
+            self.__scraper.mount('https://', HostNameIgnoringAdapter())
     
     @abstractmethod
     def props_in_source(self, source):
         pass
 
     def request(self, url):
-        return self.__scraper.get(url)
+        return self.__scraper.get(url, verify=not disable_ssl)
 
     def next_prop(self):
         for source in self.provider_data['sources']:

--- a/providers/hostname_ignoring_adapter.py
+++ b/providers/hostname_ignoring_adapter.py
@@ -1,0 +1,6 @@
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.poolmanager import PoolManager
+
+class HostNameIgnoringAdapter(HTTPAdapter):
+  def init_poolmanager(self, connections, maxsize, block=False):
+    self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, block=block, assert_hostname=False)

--- a/providers/mercadolibre.py
+++ b/providers/mercadolibre.py
@@ -23,9 +23,7 @@ class Mercadolibre(BaseProvider):
                 break
 
             for prop in properties:
-                section = prop.find('a', class_='ui-search-result__link')
-                if section is None:
-                    section = prop.find('a', class_='ui-search-result__content')
+                section = prop.find('a', class_='ui-search-result__content')
                 href = section['href']
                 matches = re.search(regex, href)
                 internal_id = matches.group(1).replace('-', '')

--- a/providers/zonaprop.py
+++ b/providers/zonaprop.py
@@ -6,7 +6,8 @@ from providers.base_provider import BaseProvider
 class Zonaprop(BaseProvider):
     def props_in_source(self, source):
         page_link = self.provider_data['base_url'] + source
-        page = 0
+        page = 1
+        processed_ids = []
 
         while(True):
             logging.info(f"Requesting {page_link}")
@@ -16,11 +17,15 @@ class Zonaprop(BaseProvider):
                 break
             
             page_content = BeautifulSoup(page_response.content, 'lxml')
-            properties = page_content.find_all('div', class_='posting-card')
+            properties = page_content.find_all('div', class_='postingCard')
 
             for prop in properties:
+                # if data-id was already processed we exit
+                if prop['data-id'] in processed_ids:
+                    return
+                processed_ids.append(prop['data-id'])
                 title = prop.find('a', class_='go-to-posting').get_text().strip()
-                price_section = prop.find('span', class_='first-price')
+                price_section = prop.find('span', class_='firstPrice')
                 if price_section is not None:
                     title = title + ' ' + price_section['data-price']
                     
@@ -32,5 +37,5 @@ class Zonaprop(BaseProvider):
                     }
 
             page += 1
-            page_link = self.provider_data['base_url'] + source + f"--pagina-{page}"
+            page_link = self.provider_data['base_url'] + source.replace(".html", f"-pagina-{page}.html")
     


### PR DESCRIPTION
This PR addresses the fact that some providers changed their HTML structured and as such the parser for those broke.

This also adds a feature to disable SSL validation for certain local scenarios, it's undoubtedly not needed for most people but for those that have a security app in their machines that intercept SSL certificates this option will help them still connect.