### PR TITLE
fix minor error log issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,8 +24,8 @@ for provider_name, provider_data in cfg['providers'].items():
     try:
         logging.info(f"Processing provider {provider_name}")
         new_properties += process_properties(provider_name, provider_data)
-    except:
-        logging.error(f"Error processing provider {provider_name}.\n{sys.exc_info()[0]}")
+    except Exception as e:
+        logging.error(f"Error processing provider {provider_name}.\n{str(e)}")
 
 if len(new_properties) > 0:
     notifier.notify(new_properties)


### PR DESCRIPTION
With python 3.9.3:

Before:

```
➜  housing_scrapper git:(minor-fix) ✗ python3 main.py
loading config
2021-05-29 21:48:50,029 - root - INFO - Setting up bot with token 957544211:AAEJ8Sw_jMP_TodZWRHd13i2gApd1_2BanY
2021-05-29 21:48:50,029 - root - INFO - Processing provider zonaprops
2021-05-29 21:48:50,029 - root - ERROR - Error processing provider zonaprops.
<class 'Exception'>
```

After

```
➜  housing_scrapper git:(minor-fix) python3 main.py 
loading config
2021-05-29 21:48:17,651 - root - INFO - Setting up bot with token 957544211:AAEJ8Sw_jMP_TodZWRHd13i2gApd1_2BanY
2021-05-29 21:48:17,651 - root - INFO - Processing provider zonaprops
2021-05-29 21:48:17,651 - root - ERROR - Error processing provider zonaprops.
Unrecognized provider
```